### PR TITLE
Add system exit when leaving child process.

### DIFF
--- a/levels/00_fork_exec/rd.py
+++ b/levels/00_fork_exec/rd.py
@@ -35,6 +35,7 @@ def run(command):
     if pid == 0:
         # This is the child, we need to exec the command
         contain(command)
+        os._exit(0)
     else:
         # This is the parent, pid contains the PID of the forked process
         _, status = os.waitpid(pid, 0)  # wait for the forked child, fetch the exit status


### PR DESCRIPTION
The thing fork now creates 2 flows in your code, so when blocking `contain()` returns, you will continue executing code. In this case no code is present post the if branch but should someone add a log / cleanup code / whatever that would run from both the parent and the child code flows. See here for better explanation of the same point http://www.python-course.eu/forking.php
