### PR TITLE
fix /swap.img permissions during vagrant bootstrap

### DIFF
--- a/packer/on_boot.sh
+++ b/packer/on_boot.sh
@@ -1,12 +1,13 @@
-#!/bin/bash -x
+#!/bin/bash
 
 mkdir -p /workshop/containers
 
 chown ubuntu:ubuntu -R /workshop
 
 if [[ $(cat /proc/swaps | wc -l) -le 1 && ! -f /swap.img ]]; then
-	dd if=/dev/zero of=/swap.img count=1024 bs=1M
+  dd if=/dev/zero of=/swap.img count=1024 bs=1M
   chmod 0600 /swap.img
-	mkswap /swap.img
-	swapon /swap.img
+  mkswap /swap.img
+  swapon /swap.img
 fi
+

--- a/packer/on_boot.sh
+++ b/packer/on_boot.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 mkdir -p /workshop/containers
 
@@ -6,6 +6,7 @@ chown ubuntu:ubuntu -R /workshop
 
 if [[ $(cat /proc/swaps | wc -l) -le 1 && ! -f /swap.img ]]; then
 	dd if=/dev/zero of=/swap.img count=1024 bs=1M
+  chmod 0600 /swap.img
 	mkswap /swap.img
 	swapon /swap.img
 fi


### PR DESCRIPTION
This fixes a file perms issue when creating a swap file in the vagrant box.

``` bash
==> default: /home/vagrant
==> default: 1024+0 records in
==> default: 1024+0 records out
==> default: 1073741824 bytes (1.1 GB) copied
==> default: , 2.06224 s, 521 MB/s
==> default: Setting up swapspace version 1, size = 1024 MiB (1073737728 bytes)
==> default: no label, UUID=28fcea3e-fa39-4a89-8e03-4b3c918ac14f
==> default: swapon:
==> default: /swap.img: insecure permissions 0644, 0600 suggested.

```
