### PR TITLE
l3: Recommend `man 2 umount`, not `man mount`

### DIFF
--- a/levels/03_pivot_root/rd.py
+++ b/levels/03_pivot_root/rd.py
@@ -96,7 +96,7 @@ def contain(command, image_name, image_dir, container_id, container_dir):
 
     os.chdir('/')
 
-    # TODO: umount2 old root (HINT: see MNT_DETACH in man mount)
+    # TODO: umount2 old root (HINT: see MNT_DETACH in man 2 umount)
 
     os.execvp(command[0], command)
 


### PR DESCRIPTION
On Arch Linux with the documentation for 4.6.3:

```
% man mount | grep -c MNT_DETACH
0
% man 2 mount | grep -c MNT_DETACH
0
% man 2 umount | grep -c MNT_DETACH
5
```
